### PR TITLE
refactor: string usage

### DIFF
--- a/src/window.rs
+++ b/src/window.rs
@@ -126,7 +126,7 @@ mod imp {
             for (index, caps) in re.captures_iter(&test_string).enumerate() {
                 let m = caps.get(0).unwrap();
 
-                if m.as_str().len() < 1 {
+                if m.is_empty() {
                     continue;
                 }
 

--- a/src/window.rs
+++ b/src/window.rs
@@ -156,7 +156,7 @@ mod imp {
                 "{matches} match",
                 "{matches} matches",
                 captures,
-                &[("matches", &"a".replace("a", &captures.to_string()))],
+                &[("matches", &captures.to_string())],
             ));
         }
     }


### PR DESCRIPTION
Improves https://github.com/fkinoshita/Wildcard/commit/6770e75f60a88346330365cf44af3281cdacd933, by using the `str` directly without replacing it first.

Also replaces the earlier length check with the more idiomatic `is_empty()`.