### PR TITLE
feat: use bind in flag dialog

### DIFF
--- a/data/resources/ui/flags_dialog.blp
+++ b/data/resources/ui/flags_dialog.blp
@@ -51,8 +51,6 @@ template $FlagsDialog : Adw.Window {
               Gtk.Switch multiline_switch {
                 can-focus: false;
                 valign: center;
-
-                notify::state => $on_multiline_changed() swapped;
               }
             }
 
@@ -64,8 +62,6 @@ template $FlagsDialog : Adw.Window {
               Gtk.Switch case_insensitive_switch {
                 can-focus: false;
                 valign: center;
-
-                notify::state => $on_case_insensitive_changed() swapped;
               }
             }
 
@@ -77,8 +73,6 @@ template $FlagsDialog : Adw.Window {
               Gtk.Switch ignore_whitespace_switch {
                 can-focus: false;
                 valign: center;
-
-                notify::state => $on_ignore_whitespace_changed() swapped;
               }
             }
 
@@ -90,8 +84,6 @@ template $FlagsDialog : Adw.Window {
               Gtk.Switch dot_matches_newline_switch {
                 can-focus: false;
                 valign: center;
-
-                notify::state => $on_dot_matches_newline_changed() swapped;
               }
             }
 
@@ -103,8 +95,6 @@ template $FlagsDialog : Adw.Window {
               Gtk.Switch unicode_switch {
                 can-focus: false;
                 valign: center;
-
-                notify::state => $on_unicode_changed() swapped;
               }
             }
 
@@ -116,8 +106,6 @@ template $FlagsDialog : Adw.Window {
               Gtk.Switch greed_switch {
                 can-focus: false;
                 valign: center;
-
-                notify::state => $on_greed_changed() swapped;
               }
             }
           }

--- a/src/flags_dialog.rs
+++ b/src/flags_dialog.rs
@@ -65,11 +65,8 @@ mod imp {
 
     impl ObjectImpl for FlagsDialog {
         fn signals() -> &'static [Signal] {
-            static SIGNALS: Lazy<Vec<Signal>> = Lazy::new(|| {
-                vec![
-                    Signal::builder("flags-changed").action().build(),
-                ]
-            });
+            static SIGNALS: Lazy<Vec<Signal>> =
+                Lazy::new(|| vec![Signal::builder("flags-changed").action().build()]);
             SIGNALS.as_ref()
         }
 
@@ -90,42 +87,60 @@ mod imp {
     impl FlagsDialog {
         #[template_callback]
         fn on_multiline_changed(&self) {
-            if let Err(err) = self.obj().set_flag_setting("multiline-flag", self.multiline_switch.is_active()) {
+            if let Err(err) = self
+                .obj()
+                .set_flag_setting("multiline-flag", self.multiline_switch.is_active())
+            {
                 log::error!("Failed to save multiline flag, {}", &err);
             }
         }
 
         #[template_callback]
         fn on_case_insensitive_changed(&self) {
-            if let Err(err) = self.obj().set_flag_setting("case-insensitive-flag", self.case_insensitive_switch.is_active()) {
+            if let Err(err) = self.obj().set_flag_setting(
+                "case-insensitive-flag",
+                self.case_insensitive_switch.is_active(),
+            ) {
                 log::error!("Failed to save case insensitive flag, {}", &err);
             }
         }
 
         #[template_callback]
         fn on_ignore_whitespace_changed(&self) {
-            if let Err(err) = self.obj().set_flag_setting("ignore-whitespace-flag", self.ignore_whitespace_switch.is_active()) {
+            if let Err(err) = self.obj().set_flag_setting(
+                "ignore-whitespace-flag",
+                self.ignore_whitespace_switch.is_active(),
+            ) {
                 log::error!("Failed to save ignore whitespace flag, {}", &err);
             }
         }
 
         #[template_callback]
         fn on_dot_matches_newline_changed(&self) {
-            if let Err(err) = self.obj().set_flag_setting("dot-matches-newline-flag", self.dot_matches_newline_switch.is_active()) {
+            if let Err(err) = self.obj().set_flag_setting(
+                "dot-matches-newline-flag",
+                self.dot_matches_newline_switch.is_active(),
+            ) {
                 log::error!("Failed to save dot matches newline flag, {}", &err);
             }
         }
 
         #[template_callback]
         fn on_unicode_changed(&self) {
-            if let Err(err) = self.obj().set_flag_setting("unicode-flag", self.unicode_switch.is_active()) {
+            if let Err(err) = self
+                .obj()
+                .set_flag_setting("unicode-flag", self.unicode_switch.is_active())
+            {
                 log::error!("Failed to save unicode flag, {}", &err);
             }
         }
 
         #[template_callback]
         fn on_greed_changed(&self) {
-            if let Err(err) = self.obj().set_flag_setting("greed-flag", self.greed_switch.is_active()) {
+            if let Err(err) = self
+                .obj()
+                .set_flag_setting("greed-flag", self.greed_switch.is_active())
+            {
                 log::error!("Failed to save greed flag, {}", &err);
             }
         }
@@ -142,6 +157,7 @@ glib::wrapper! {
 }
 
 impl FlagsDialog {
+    #[warn(clippy::new_without_default)]
     pub fn new() -> Self {
         glib::Object::builder().build()
     }
@@ -149,15 +165,25 @@ impl FlagsDialog {
     fn load_flags(&self) {
         let imp = self.imp();
 
-        imp.multiline_switch.set_active(imp.settings.boolean("multiline-flag"));
-        imp.case_insensitive_switch.set_active(imp.settings.boolean("case-insensitive-flag"));
-        imp.ignore_whitespace_switch.set_active(imp.settings.boolean("ignore-whitespace-flag"));
-        imp.dot_matches_newline_switch.set_active(imp.settings.boolean("dot-matches-newline-flag"));
-        imp.unicode_switch.set_active(imp.settings.boolean("unicode-flag"));
-        imp.greed_switch.set_active(imp.settings.boolean("greed-flag"));
+        imp.multiline_switch
+            .set_active(imp.settings.boolean("multiline-flag"));
+        imp.case_insensitive_switch
+            .set_active(imp.settings.boolean("case-insensitive-flag"));
+        imp.ignore_whitespace_switch
+            .set_active(imp.settings.boolean("ignore-whitespace-flag"));
+        imp.dot_matches_newline_switch
+            .set_active(imp.settings.boolean("dot-matches-newline-flag"));
+        imp.unicode_switch
+            .set_active(imp.settings.boolean("unicode-flag"));
+        imp.greed_switch
+            .set_active(imp.settings.boolean("greed-flag"));
     }
 
-    fn set_flag_setting(&self, setting_name: &str, setting_value: bool) -> Result<(), glib::BoolError> {
+    fn set_flag_setting(
+        &self,
+        setting_name: &str,
+        setting_value: bool,
+    ) -> Result<(), glib::BoolError> {
         let imp = self.imp();
 
         imp.settings.set_boolean(setting_name, setting_value)?;

--- a/src/flags_dialog.rs
+++ b/src/flags_dialog.rs
@@ -55,7 +55,6 @@ mod imp {
 
         fn class_init(klass: &mut Self::Class) {
             klass.bind_template();
-            klass.bind_template_callbacks();
         }
 
         fn instance_init(obj: &glib::subclass::InitializingObject<Self>) {
@@ -83,69 +82,6 @@ mod imp {
         }
     }
 
-    #[gtk::template_callbacks]
-    impl FlagsDialog {
-        #[template_callback]
-        fn on_multiline_changed(&self) {
-            if let Err(err) = self
-                .obj()
-                .set_flag_setting("multiline-flag", self.multiline_switch.is_active())
-            {
-                log::error!("Failed to save multiline flag, {}", &err);
-            }
-        }
-
-        #[template_callback]
-        fn on_case_insensitive_changed(&self) {
-            if let Err(err) = self.obj().set_flag_setting(
-                "case-insensitive-flag",
-                self.case_insensitive_switch.is_active(),
-            ) {
-                log::error!("Failed to save case insensitive flag, {}", &err);
-            }
-        }
-
-        #[template_callback]
-        fn on_ignore_whitespace_changed(&self) {
-            if let Err(err) = self.obj().set_flag_setting(
-                "ignore-whitespace-flag",
-                self.ignore_whitespace_switch.is_active(),
-            ) {
-                log::error!("Failed to save ignore whitespace flag, {}", &err);
-            }
-        }
-
-        #[template_callback]
-        fn on_dot_matches_newline_changed(&self) {
-            if let Err(err) = self.obj().set_flag_setting(
-                "dot-matches-newline-flag",
-                self.dot_matches_newline_switch.is_active(),
-            ) {
-                log::error!("Failed to save dot matches newline flag, {}", &err);
-            }
-        }
-
-        #[template_callback]
-        fn on_unicode_changed(&self) {
-            if let Err(err) = self
-                .obj()
-                .set_flag_setting("unicode-flag", self.unicode_switch.is_active())
-            {
-                log::error!("Failed to save unicode flag, {}", &err);
-            }
-        }
-
-        #[template_callback]
-        fn on_greed_changed(&self) {
-            if let Err(err) = self
-                .obj()
-                .set_flag_setting("greed-flag", self.greed_switch.is_active())
-            {
-                log::error!("Failed to save greed flag, {}", &err);
-            }
-        }
-    }
-
     impl WidgetImpl for FlagsDialog {}
     impl WindowImpl for FlagsDialog {}
     impl AdwWindowImpl for FlagsDialog {}
@@ -157,7 +93,7 @@ glib::wrapper! {
 }
 
 impl FlagsDialog {
-    #[warn(clippy::new_without_default)]
+    #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
         glib::Object::builder().build()
     }
@@ -165,30 +101,23 @@ impl FlagsDialog {
     fn load_flags(&self) {
         let imp = self.imp();
 
-        imp.multiline_switch
-            .set_active(imp.settings.boolean("multiline-flag"));
-        imp.case_insensitive_switch
-            .set_active(imp.settings.boolean("case-insensitive-flag"));
-        imp.ignore_whitespace_switch
-            .set_active(imp.settings.boolean("ignore-whitespace-flag"));
-        imp.dot_matches_newline_switch
-            .set_active(imp.settings.boolean("dot-matches-newline-flag"));
-        imp.unicode_switch
-            .set_active(imp.settings.boolean("unicode-flag"));
-        imp.greed_switch
-            .set_active(imp.settings.boolean("greed-flag"));
+        self.bind_flag("multiline-flag", &imp.multiline_switch);
+        self.bind_flag("case-insensitive-flag", &imp.case_insensitive_switch);
+        self.bind_flag("ignore-whitespace-flag", &imp.ignore_whitespace_switch);
+        self.bind_flag("dot-matches-newline-flag", &imp.dot_matches_newline_switch);
+        self.bind_flag("unicode-flag", &imp.unicode_switch);
+        self.bind_flag("greed-flag", &imp.greed_switch);
     }
 
-    fn set_flag_setting(
-        &self,
-        setting_name: &str,
-        setting_value: bool,
-    ) -> Result<(), glib::BoolError> {
+    fn bind_flag(&self, setting_name: &str, switch: &TemplateChild<gtk::Switch>) {
         let imp = self.imp();
 
-        imp.settings.set_boolean(setting_name, setting_value)?;
-        self.emit_by_name::<()>("flags-changed", &[]);
-
-        Ok(())
+        imp.settings.bind(setting_name, &**switch, "active").build();
+        imp.settings.connect_changed(
+            Some(setting_name),
+            glib::clone!(@weak self as dialog => move |_setting, _value| {
+                dialog.emit_by_name::<()>("flags-changed", &[]);
+            }),
+        );
     }
 }

--- a/src/window.rs
+++ b/src/window.rs
@@ -253,11 +253,12 @@ impl Window {
             "flags-changed",
             false,
             glib::clone!(@strong self as this => move |_| {
-                this.imp().test_buffer.emit_by_name::<()>("changed", &[]);
+                    this.imp().test_buffer.emit_by_name::<()>("changed", &[]);
 
-                None
-            }
-        ));
+                    None
+                }
+            ),
+        );
 
         dialog.set_transient_for(Some(self));
         dialog.set_modal(true);
@@ -280,7 +281,7 @@ impl Window {
             .developers(vec!["Felipe Kinoshita <fkinoshita@gnome.org>"])
             .artists(vec!["kramo https://kramo.hu"])
             .copyright("© 2023 Felipe Kinoshita.")
-            .release_notes(&gettext("
+            .release_notes(gettext("
                 <p>This is minor release of Wildcard brings much needed fixes and improvements:</p>
                 <ul>
                   <li>Fixed scrolling issues on the text views</li>

--- a/src/window.rs
+++ b/src/window.rs
@@ -99,7 +99,7 @@ mod imp {
                 .unicode(self.settings.boolean("unicode-flag"))
                 .swap_greed(self.settings.boolean("greed-flag"))
                 .build()
-                .unwrap_or(Regex::new(r"").unwrap());
+                .unwrap_or_else(|_err| Regex::new(r"").unwrap());
 
             self.test_buffer
                 .remove_all_tags(&self.test_buffer.start_iter(), &self.test_buffer.end_iter());


### PR DESCRIPTION
Rewrites parts of the flag dialog to use bind to bind the settings to the switches directly. This removes the need for separate template callback functions for each switch. There is probably an even better way to emit a callback when the setting is changed but, besides directly listening to the setting, I'm not aware of it.

Also includes minor improvements like applying `clippy`, `fmt` and using `urnwarp_or_else`.